### PR TITLE
Add example of math notation

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to {{ cookiecutter.project_name }}'s documentation!
    readme
    installation
    usage
+   math
    modules
    contributing
    {% if cookiecutter.create_author_file == 'y' -%}authors

--- a/{{cookiecutter.project_slug}}/docs/math.rst
+++ b/{{cookiecutter.project_slug}}/docs/math.rst
@@ -1,0 +1,9 @@
+=====================
+Math notation example
+=====================
+
+When we describe the methods a repository implements, we frequently need to express some of the variables via inline mathematical notation (e.g. :math:`t` and :math:`\tau_i`) and some of their relations in displayed mathematical notation: 
+
+.. math:: t = \sum_{i=1}^n e^{\frac{1}{\tau_i}}
+
+This page serves as an example of how such is done. 


### PR DESCRIPTION
To help new users implement their math notation as mathjax-rendered-latex rather than including pngs.